### PR TITLE
Add support for CSPM urls for different regions to the Trivy Docker Extension 

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,6 +17,7 @@ import { SendMetric } from './Metrics';
 export function App() {
   const [aquaKey, setAquaKey] = React.useState("");
   const [aquaSecret, setAquaSecret] = React.useState("");
+  const [aquaCSPMUrl, setAquaCSPMUrl] = React.useState("");
 
   const [scanImage, setScanImage] = React.useState("");
   const [disableScan, setDisableScan] = React.useState(true);
@@ -135,6 +136,8 @@ export function App() {
       commandParts.push("AQUA_KEY=" + aquaKey);
       commandParts.push("-e");
       commandParts.push("AQUA_SECRET=" + aquaSecret);
+      commandParts.push("-e");
+      commandParts.push("CSPM_URL=" + aquaCSPMUrl);
     }
 
 
@@ -338,7 +341,8 @@ export function App() {
     window.ddClient.extension.vm.service.get("/credentials").then((value: any) => {
       setAquaKey(value.aqua_key);
       setAquaSecret(value.aqua_secret);
-      if (value.aqua_key !== "" && value.aqua_secret !== "") {
+      setAquaCSPMUrl(value.aqua_cspm_url);
+      if (value.aqua_key !== "" && value.aqua_secret !== "" && value.aqua_cspm_url !== "") {
         setLoggedIn(true);
       }
     }).catch((err: any) => {
@@ -360,6 +364,8 @@ export function App() {
           setAquaKey={setAquaKey}
           aquaSecret={aquaSecret}
           setAquaSecret={setAquaSecret}
+          aquaCSPMUrl={aquaCSPMUrl}
+          setAquaCSPMUrl={setAquaCSPMUrl}
           loggedIn={loggedIn}
           setLoggedIn={setLoggedIn}
         />

--- a/client/src/ConfigureCreds.tsx
+++ b/client/src/ConfigureCreds.tsx
@@ -23,7 +23,7 @@ export function ConfigureCreds(props: any) {
     };
 
     const handleSaveDetails = () => {
-        let payload = { aqua_key: props.aquaKey, aqua_secret: props.aquaSecret };
+        let payload = { aqua_key: props.aquaKey, aqua_secret: props.aquaSecret, aqua_cspm_url: props.aquaCSPMUrl };
         console.log(payload);
         window.ddClient.extension.vm.service.request({ url: "/credentials", method: "POST", headers: { 'Content-Type': 'application/json' }, data: payload })
             .then(() => {
@@ -41,6 +41,7 @@ export function ConfigureCreds(props: any) {
                 SendMetric("trivy_aqua_login_failed", { aquaKey: props.aquaKey });
                 props.setAquaKey("");
                 props.setAquaSecret("");
+                props.setAquaCSPMUrl("");
                 console.log(error);
             });
     };
@@ -48,6 +49,7 @@ export function ConfigureCreds(props: any) {
     const handleSignOutClick = () => {
         props.setAquaKey("");
         props.setAquaSecret("");
+        props.setAquaCSPMUrl("");
         props.setLoggedIn(false);
 
         let payload = { aqua_key: "", aqua_secret: "" };
@@ -94,7 +96,7 @@ export function ConfigureCreds(props: any) {
                         onChange={(e) => props.setAquaKey(e.target.value)}
                         fullWidth
                         variant="standard"
-                        helperText="AQUA_KEY provided in you CSPM account"
+                        helperText="AQUA_KEY provided in your CSPM account"
                     />
                     <TextField
                         margin="dense"
@@ -105,8 +107,19 @@ export function ConfigureCreds(props: any) {
                         onChange={(e) => props.setAquaSecret(e.target.value)}
                         fullWidth
                         variant="standard"
-                        helperText="AQUA_SECRET provided in you CSPM account"
+                        helperText="AQUA_SECRET provided in your CSPM account"
                     />
+                  <TextField
+                    margin="dense"
+                    id="aquaCSPMUrl"
+                    label="Aqua CSPM Url"
+                    type="text"
+                    value={props.aquaCSPMUrl}
+                    onChange={(e) => props.setAquaCSPMUrl(e.target.value)}
+                    fullWidth
+                    variant="standard"
+                    helperText="AQUA_CSPM_URL provided in your CSPM account"
+                  />
 
                 </DialogContent>
                 <DialogActions>

--- a/service/internal/auth/validate.go
+++ b/service/internal/auth/validate.go
@@ -19,12 +19,12 @@ type Response struct {
 	Errors  []string `json:"errors,omitempty"`
 }
 
-const cspmUrl = "https://api.cloudsploit.com/v2/tokens"
+const cspmTokenExchangePath = "/v2/tokens"
 
-func ValidateCredentials(key, secret string) (string, error) {
+func ValidateCredentials(key, secret, cspmUrl string) (string, error) {
 	body := `{"validity":30,"allowed_endpoints":["ANY:v2/build/twirp/buildsecurity.BuildSecurity/*"]}`
 
-	req, err := http.NewRequest("POST", cspmUrl, bytes.NewBuffer([]byte(body)))
+	req, err := http.NewRequest("POST", cspmUrl+cspmTokenExchangePath, bytes.NewBuffer([]byte(body)))
 	if err != nil {
 		return "", err
 	}

--- a/service/main.go
+++ b/service/main.go
@@ -18,8 +18,9 @@ import (
 const credsFile = "/creds/.aqua"
 
 type Credentials struct {
-	AquaKey    string `json:"aqua_key"`
-	AquaSecret string `json:"aqua_secret"`
+	AquaKey     string `json:"aqua_key"`
+	AquaSecret  string `json:"aqua_secret"`
+	AquaCSPMUrl string `json:"aqua_cspm_url"`
 }
 
 func main() {
@@ -66,7 +67,7 @@ func writeCredentials(ctx echo.Context) error {
 	if err := ctx.Bind(creds); err != nil {
 		return internalError(ctx, err)
 	}
-	validated, err := auth.ValidateCredentials(creds.AquaKey, creds.AquaSecret)
+	validated, err := auth.ValidateCredentials(creds.AquaKey, creds.AquaSecret, creds.AquaCSPMUrl)
 	if err != nil || validated == "" {
 		return internalError(ctx, err)
 	}


### PR DESCRIPTION
Currently the login button fails for any Aqua CSPM client that is not hosted in the US Region. This is because the login url was hardcoded to the US region in `validate.go`

I've fixed this and also updated the frontend to allow the user to specify their own region on the login screen.

Tested locally following the local deployment instructions